### PR TITLE
Allow posters to be placed by introducing a flag

### DIFF
--- a/build_restriction.lua
+++ b/build_restriction.lua
@@ -1,7 +1,7 @@
 
 minetest.register_on_mods_loaded(function()
   for name, nodedef in pairs(minetest.registered_nodes) do
-    if nodedef.epic then
+    if nodedef.epic and not nodedef.epic_anyone_can_place then
       minetest.override_item(name, {
         on_place = function(itemstack, placer, pointed_thing)
           local playername = (placer and placer:get_player_name()) or ""

--- a/compat/signs_paper_poster.lua
+++ b/compat/signs_paper_poster.lua
@@ -13,6 +13,7 @@ minetest.override_item("signs:paper_poster", {
 		old_on_receive_fields(pos, formname, fields, player)
 	end,
 
+	epic_anyone_can_place = true,
 	epic = {
 		on_enter = function(pos, _, player)
 			closed_forms[player:get_player_name()] = nil


### PR DESCRIPTION
The epic callbacks attached to the poster are causing them to be unplaceable by those who don't have the epic_builder priv

By introducing the `epic_anyone_can_place` flag we can remove this behaviour.

Though I prefer to write flags in the positive, like `epic_requires_priv` I chose to go for the simplest solution instead of changing every epic block definition