### PR TITLE
Add action log for all potentially dangerous operations

### DIFF
--- a/blocks/add_item.lua
+++ b/blocks/add_item.lua
@@ -36,7 +36,7 @@ local function do_add_item(pos, meta)
 	if stack:is_empty() then return end
 
 	local absolute_pos = epic.to_absolute_pos(pos, target_pos)
-	minetest.log("action", ("%s item added at %s"):format(stack:to_string(),  minetest.pos_to_string(absolute_pos)))
+	minetest.log("action", ("[epic::add_item@%s] %s item added at %s"):format(minetest.pos_to_string(pos), stack:to_string(),  minetest.pos_to_string(absolute_pos)))
 	minetest.add_item(absolute_pos, stack)
 end
 

--- a/blocks/add_item.lua
+++ b/blocks/add_item.lua
@@ -33,7 +33,11 @@ local function do_add_item(pos, meta)
 
 	local inv = meta:get_inventory()
 	local stack = inv:get_stack("main", 1)
-	minetest.add_item(epic.to_absolute_pos(pos, target_pos), stack)
+	if stack:is_empty() then return end
+
+	local absolute_pos = epic.to_absolute_pos(pos, target_pos)
+	minetest.log("action", ("%s item added at %s"):format(stack:to_string(),  minetest.pos_to_string(absolute_pos)))
+	minetest.add_item(absolute_pos, stack)
 end
 
 minetest.register_node("epic:additem", {

--- a/blocks/add_item.lua
+++ b/blocks/add_item.lua
@@ -36,7 +36,8 @@ local function do_add_item(pos, meta)
 	if stack:is_empty() then return end
 
 	local absolute_pos = epic.to_absolute_pos(pos, target_pos)
-	minetest.log("action", ("[epic::add_item@%s] %s item added at %s"):format(minetest.pos_to_string(pos), stack:to_string(),  minetest.pos_to_string(absolute_pos)))
+	minetest.log("action", ("[epic::add_item@%s] %s item added at %s")
+		:format(minetest.pos_to_string(pos), stack:to_string(),  minetest.pos_to_string(absolute_pos)))
 	minetest.add_item(absolute_pos, stack)
 end
 

--- a/blocks/deduct_inventory.lua
+++ b/blocks/deduct_inventory.lua
@@ -58,9 +58,18 @@ minetest.register_node("epic:deduct_inv", {
       end
 
 			if success then
+				local deduct_string = ""
+				local items_deducted = false
 				for _, deduct_item in ipairs(deduct_items) do
-					player_inv:remove_item("main", deduct_item)
-	      end
+					if not deduct_item:is_empty() then
+						deduct_string = deduct_string .. deduct_item:to_string() .. ", "
+						items_deducted = true
+						player_inv:remove_item("main", deduct_item)
+					end
+				end
+				if items_deducted then
+					minetest.log("action", ("{ %s } deducted from %s's inventory"):format(deduct_string:sub(1,-3),  player:get_player_name()))
+				end
 
 				ctx.next()
 			end

--- a/blocks/deduct_inventory.lua
+++ b/blocks/deduct_inventory.lua
@@ -44,7 +44,7 @@ minetest.register_node("epic:deduct_inv", {
 	end,
 
 	epic = {
-    on_check = function(_, meta, player, ctx)
+    on_check = function(pos, meta, player, ctx)
 			local inv = meta:get_inventory()
 			local player_inv = player:get_inventory()
 
@@ -68,8 +68,8 @@ minetest.register_node("epic:deduct_inv", {
 					end
 				end
 				if items_deducted then
-					minetest.log("action", ("{ %s } deducted from %s's inventory")
-						:format(deduct_string:sub(1,-3),  player:get_player_name()))
+					minetest.log("action", ("[epic::deduct_inventory@%s] { %s } deducted from %s's inventory")
+						:format(minetest.pos_to_string(pos), deduct_string:sub(1,-3),  player:get_player_name()))
 				end
 
 				ctx.next()

--- a/blocks/deduct_inventory.lua
+++ b/blocks/deduct_inventory.lua
@@ -68,7 +68,8 @@ minetest.register_node("epic:deduct_inv", {
 					end
 				end
 				if items_deducted then
-					minetest.log("action", ("{ %s } deducted from %s's inventory"):format(deduct_string:sub(1,-3),  player:get_player_name()))
+					minetest.log("action", ("{ %s } deducted from %s's inventory")
+						:format(deduct_string:sub(1,-3),  player:get_player_name()))
 				end
 
 				ctx.next()

--- a/blocks/fill_chest.lua
+++ b/blocks/fill_chest.lua
@@ -34,6 +34,20 @@ local function do_fill(pos, meta)
 
 	local target_meta = minetest.get_meta(target_pos)
 	local target_inv = target_meta:get_inventory()
+	local existing_items = target_inv:get_list("main")
+	local existing_items_string = ""
+	for _,stack in pairs(existing_items) do
+		if not stack:is_empty() then
+			existing_items_string = existing_items_string .. stack:to_string() .. ", "
+		end
+	end
+	local new_items_string = ""
+	for _,stack in pairs(items) do
+		if not stack:is_empty() then
+			new_items_string = new_items_string .. stack:to_string() .. ", "
+		end
+	end
+	minetest.log("action", ("Inventory at %s replaced { %s } with { %s }"):format(minetest.pos_to_string(target_pos), existing_items_string:sub(1, -3),  new_items_string:sub(1, -3)))
 	target_inv:set_list("main", items)
 end
 

--- a/blocks/fill_chest.lua
+++ b/blocks/fill_chest.lua
@@ -47,8 +47,13 @@ local function do_fill(pos, meta)
 			new_items_string = new_items_string .. stack:to_string() .. ", "
 		end
 	end
-	minetest.log("action", ("Inventory at %s replaced { %s } with { %s }")
-		:format(minetest.pos_to_string(target_pos), existing_items_string:sub(1, -3),  new_items_string:sub(1, -3)))
+	minetest.log("action", ("[epic::fill_chest@%s] Inventory at %s replaced { %s } with { %s }")
+		:format(
+			minetest.pos_to_string(pos),
+			minetest.pos_to_string(target_pos),
+			existing_items_string:sub(1, -3),
+			new_items_string:sub(1, -3)
+		))
 	target_inv:set_list("main", items)
 end
 

--- a/blocks/fill_chest.lua
+++ b/blocks/fill_chest.lua
@@ -47,7 +47,8 @@ local function do_fill(pos, meta)
 			new_items_string = new_items_string .. stack:to_string() .. ", "
 		end
 	end
-	minetest.log("action", ("Inventory at %s replaced { %s } with { %s }"):format(minetest.pos_to_string(target_pos), existing_items_string:sub(1, -3),  new_items_string:sub(1, -3)))
+	minetest.log("action", ("Inventory at %s replaced { %s } with { %s }")
+		:format(minetest.pos_to_string(target_pos), existing_items_string:sub(1, -3),  new_items_string:sub(1, -3)))
 	target_inv:set_list("main", items)
 end
 

--- a/blocks/filter_inventory.lua
+++ b/blocks/filter_inventory.lua
@@ -56,7 +56,7 @@ minetest.register_node("epic:filter_inv", {
 	end,
 
 	epic = {
-    on_check = function(_, meta, player, ctx)
+    on_check = function(pos, meta, player, ctx)
 			local inv = meta:get_inventory()
 			local player_inv = player:get_inventory()
 
@@ -83,8 +83,8 @@ minetest.register_node("epic:filter_inv", {
 			end
 
 			if items_removed then
-				minetest.log("action", ("{ %s } filtered from %s's inventory")
-					:format(removed_string:sub(1,-3),  player:get_player_name()))
+				minetest.log("action", ("[epic::filter_inventory@%s] { %s } filtered from %s's inventory")
+					:format(minetest.pos_to_string(pos), removed_string:sub(1,-3),  player:get_player_name()))
 			end
 
 			ctx.next()

--- a/blocks/filter_inventory.lua
+++ b/blocks/filter_inventory.lua
@@ -13,11 +13,14 @@ end
 
 local function filter_inventory(inv, listname, filter_names)
 	local list = inv:get_list(listname)
+	local removed = {}
 	for i, stack in ipairs(list) do
 		if filter_names[stack:get_name()] then
 			inv:set_stack(listname, i, ItemStack(""))
+			table.insert(removed, stack)
 		end
 	end
+	return removed
 end
 
 minetest.register_node("epic:filter_inv", {
@@ -65,8 +68,23 @@ minetest.register_node("epic:filter_inv", {
 				end
       end
 
-			filter_inventory(player_inv, "main", filter_names)
-			filter_inventory(player_inv, "craft", filter_names)
+
+			local removed_main = filter_inventory(player_inv, "main", filter_names)
+			local removed_craft = filter_inventory(player_inv, "craft", filter_names)
+			local removed_string = ""
+			local items_removed = false
+			for _,list in pairs({removed_main,removed_craft}) do
+				for _,stack in pairs(list) do
+					if not stack:is_empty() then
+						removed_string = removed_string .. stack:to_string() .. ", "
+						items_removed = true
+					end
+				end
+			end
+
+			if items_removed then
+				minetest.log("action", ("{ %s } filtered from %s's inventory"):format(removed_string:sub(1,-3),  player:get_player_name()))
+			end
 
 			ctx.next()
 

--- a/blocks/filter_inventory.lua
+++ b/blocks/filter_inventory.lua
@@ -83,7 +83,8 @@ minetest.register_node("epic:filter_inv", {
 			end
 
 			if items_removed then
-				minetest.log("action", ("{ %s } filtered from %s's inventory"):format(removed_string:sub(1,-3),  player:get_player_name()))
+				minetest.log("action", ("{ %s } filtered from %s's inventory")
+					:format(removed_string:sub(1,-3),  player:get_player_name()))
 			end
 
 			ctx.next()

--- a/blocks/remove_item.lua
+++ b/blocks/remove_item.lua
@@ -27,10 +27,24 @@ local function do_remove(pos, meta)
 	end
 
 	local objects = minetest.get_objects_inside_radius(target_pos, radius)
-	for _, object in ipairs(objects) do
-		object:remove()
-	end
 
+	local objects_string = ""
+	local objects_removed = false
+	for _, object in ipairs(objects) do
+		if not object:is_player() then
+			local lua_entity = object:get_luaentity()
+			objects_string = objects_string ..
+				(lua_entity.itemstring or lua_entity.name) ..
+				(lua_entity.dropped_by and (" (dropped by " .. lua_entity.dropped_by .. ")") or "") ..
+				", "
+			objects_removed = true
+
+			object:remove()
+		end
+	end
+	if objects_removed then
+		minetest.log("action", ("Items removed { %s }"):format(objects_string:sub(1,-3)))
+	end
 end
 
 minetest.register_node("epic:removeitem", {

--- a/blocks/remove_item.lua
+++ b/blocks/remove_item.lua
@@ -43,7 +43,8 @@ local function do_remove(pos, meta)
 		end
 	end
 	if objects_removed then
-		minetest.log("action", ("Items removed { %s }"):format(objects_string:sub(1,-3)))
+		minetest.log("action", ("[epic::remove_item@%s] Items removed { %s }")
+			:format(minetest.pos_to_string(pos), objects_string:sub(1,-3)))
 	end
 end
 

--- a/blocks/set_clouds.lua
+++ b/blocks/set_clouds.lua
@@ -64,7 +64,7 @@ minetest.register_node("epic:setclouds", {
   end,
 
 	epic = {
-    on_enter = function(_, meta, player, ctx)
+    on_enter = function(pos, meta, player, ctx)
 			local existing_clouds = player:get_clouds()
 			local new_clouds = {
 				thickness = meta:get_int("thickness"),
@@ -87,8 +87,9 @@ minetest.register_node("epic:setclouds", {
 					x=meta:get_int("speedx")
 				}
 			}
-			minetest.log("action", ("%s's clouds changed from %s to %s")
+			minetest.log("action", ("[epic::set_clouds@%s] %s's clouds changed from %s to %s")
 				:format(
+					minetest.pos_to_string(pos),
 					player:get_player_name(),
 					minetest.serialize(existing_clouds):sub(8),
 					minetest.serialize(new_clouds):sub(8)

--- a/blocks/set_clouds.lua
+++ b/blocks/set_clouds.lua
@@ -88,7 +88,11 @@ minetest.register_node("epic:setclouds", {
 				}
 			}
 			minetest.log("action", ("%s's clouds changed from %s to %s")
-				:format(player:get_player_name(), minetest.serialize(existing_clouds):sub(8), minetest.serialize(new_clouds):sub(8)))
+				:format(
+					player:get_player_name(),
+					minetest.serialize(existing_clouds):sub(8),
+					minetest.serialize(new_clouds):sub(8)
+				))
 
 			player:set_clouds(new_clouds)
 			ctx.next()

--- a/blocks/set_clouds.lua
+++ b/blocks/set_clouds.lua
@@ -65,7 +65,8 @@ minetest.register_node("epic:setclouds", {
 
 	epic = {
     on_enter = function(_, meta, player, ctx)
-			player:set_clouds({
+			local existing_clouds = player:get_clouds()
+			local new_clouds = {
 				thickness = meta:get_int("thickness"),
 				color = {
 					r=meta:get_int("red"),
@@ -85,7 +86,11 @@ minetest.register_node("epic:setclouds", {
 					y=meta:get_int("speedy"),
 					x=meta:get_int("speedx")
 				}
-			})
+			}
+			minetest.log("action", ("%s's clouds changed from %s to %s")
+				:format(player:get_player_name(), minetest.serialize(existing_clouds):sub(8), minetest.serialize(new_clouds):sub(8)))
+
+			player:set_clouds(new_clouds)
 			ctx.next()
     end
   }

--- a/blocks/set_day_night.lua
+++ b/blocks/set_day_night.lua
@@ -50,8 +50,10 @@ minetest.register_node("epic:daynightratio", {
   end,
 
   epic = {
-    on_enter = function(_, meta, player, ctx)
+    on_enter = function(pos, meta, player, ctx)
 			local ratio = meta:get_string("ratio")
+			minetest.log("action", ("[epic::set_day_night@%s] %s's day-night ratio set to %s")
+				:format(minetest.pos_to_string(pos), player:get_player_name(), ratio))
 			if ratio == "" then
 				player:override_day_night_ratio(nil)
 			else

--- a/blocks/set_gravity.lua
+++ b/blocks/set_gravity.lua
@@ -50,6 +50,7 @@ minetest.register_node("epic:set_gravity", {
 	else
 		player:set_physics_override({ gravity = gravity })
 	end
+	minetest.log("action", ("%s's gravity set to %f"):format(player:get_player_name(), gravity))
 	ctx.next()
     end
   }

--- a/blocks/set_gravity.lua
+++ b/blocks/set_gravity.lua
@@ -43,14 +43,15 @@ minetest.register_node("epic:set_gravity", {
   end,
 
   epic = {
-    on_enter = function(_, meta, player, ctx)
+    on_enter = function(pos, meta, player, ctx)
 	local gravity = tonumber(meta:get_string("gravity")) or 1
 	if use_player_monoids then
 		player_monoids.gravity:add_change(player, gravity, "epic:set_gravity")
 	else
 		player:set_physics_override({ gravity = gravity })
 	end
-	minetest.log("action", ("%s's gravity set to %f"):format(player:get_player_name(), gravity))
+	minetest.log("action", ("[epic::set_gravity@%s] %s's gravity set to %f")
+		:format(minetest.pos_to_string(pos), player:get_player_name(), gravity))
 	ctx.next()
     end
   }

--- a/blocks/set_node.lua
+++ b/blocks/set_node.lua
@@ -34,8 +34,9 @@ local function do_set(pos, meta)
 		node_name = "air"
 	end
 	local previous_node = minetest.get_node_or_nil(target_pos)
-	minetest.log("action", ("%s node placed at %s, replacing %s")
+	minetest.log("action", ("[epic::set_node@%s] %s node placed at %s, replacing %s")
 		:format(
+			minetest.pos_to_string(pos),
 			node_name,
 			minetest.pos_to_string(target_pos),
 			previous_node

--- a/blocks/set_node.lua
+++ b/blocks/set_node.lua
@@ -33,6 +33,8 @@ local function do_set(pos, meta)
 	if node_name == "ignore" or node_name == "" then
 		node_name = "air"
 	end
+	local previous_node = minetest.get_node_or_nil(target_pos)
+	minetest.log("action", ("%s node placed at %s, replacing %s"):format(node_name,  minetest.pos_to_string(target_pos), previous_node and ("%s:%i:%i"):format(previous_node.name, previous_node.param1, previous_node.param2) or 'unloaded'))
 	minetest.set_node(target_pos, { name = node_name })
 end
 

--- a/blocks/set_node.lua
+++ b/blocks/set_node.lua
@@ -34,7 +34,14 @@ local function do_set(pos, meta)
 		node_name = "air"
 	end
 	local previous_node = minetest.get_node_or_nil(target_pos)
-	minetest.log("action", ("%s node placed at %s, replacing %s"):format(node_name,  minetest.pos_to_string(target_pos), previous_node and ("%s:%i:%i"):format(previous_node.name, previous_node.param1, previous_node.param2) or 'unloaded'))
+	minetest.log("action", ("%s node placed at %s, replacing %s")
+		:format(
+			node_name,
+			minetest.pos_to_string(target_pos),
+			previous_node
+				and ("%s:%i:%i"):format(previous_node.name, previous_node.param1, previous_node.param2)
+				or 'unloaded'
+		))
 	minetest.set_node(target_pos, { name = node_name })
 end
 

--- a/blocks/set_param2.lua
+++ b/blocks/set_param2.lua
@@ -23,7 +23,8 @@ local function do_set_param2(pos, meta)
 	local param2 = meta:get_string("param2")
 	local new_param2 = tonumber(param2) or 0
 
-	minetest.log("action", ("Param2 for node at %s changed from %i to %i"):format(minetest.pos_to_string(abs_pos), node.param2, new_param2))
+	minetest.log("action", ("Param2 for node at %s changed from %i to %i")
+		:format(minetest.pos_to_string(abs_pos), node.param2, new_param2))
 	node.param2 = new_param2
 	minetest.swap_node(abs_pos, node)
 end

--- a/blocks/set_param2.lua
+++ b/blocks/set_param2.lua
@@ -23,8 +23,8 @@ local function do_set_param2(pos, meta)
 	local param2 = meta:get_string("param2")
 	local new_param2 = tonumber(param2) or 0
 
-	minetest.log("action", ("Param2 for node at %s changed from %i to %i")
-		:format(minetest.pos_to_string(abs_pos), node.param2, new_param2))
+	minetest.log("action", ("[epic::set_param2@%s] Param2 for node at %s changed from %i to %i")
+		:format(minetest.pos_to_string(pos), minetest.pos_to_string(abs_pos), node.param2, new_param2))
 	node.param2 = new_param2
 	minetest.swap_node(abs_pos, node)
 end

--- a/blocks/set_param2.lua
+++ b/blocks/set_param2.lua
@@ -21,8 +21,10 @@ local function do_set_param2(pos, meta)
 
 	local node = epic.get_node(abs_pos)
 	local param2 = meta:get_string("param2")
+	local new_param2 = tonumber(param2) or 0
 
-	node.param2 = tonumber(param2) or 0
+	minetest.log("action", ("Param2 for node at %s changed from %i to %i"):format(minetest.pos_to_string(abs_pos), node.param2, new_param2))
+	node.param2 = new_param2
 	minetest.swap_node(abs_pos, node)
 end
 

--- a/blocks/stash_inventory.lua
+++ b/blocks/stash_inventory.lua
@@ -77,7 +77,8 @@ minetest.register_node("epic:stash_inv", {
       end
 
       if items_stashed then
-			minetest.log("action", ("%s's inventory has had items stashed: { %s }"):format(player:get_player_name(), stashed_string:sub(1, -3)))
+			minetest.log("action", ("%s's inventory has had items stashed: { %s }")
+				:format(player:get_player_name(), stashed_string:sub(1, -3)))
       end
 
 			ctx.next()

--- a/blocks/stash_inventory.lua
+++ b/blocks/stash_inventory.lua
@@ -44,7 +44,7 @@ minetest.register_node("epic:stash_inv", {
 	end,
 
 	epic = {
-    on_enter = function(_, meta, player, ctx)
+    on_enter = function(pos, meta, player, ctx)
       ctx.data.stashed_items = ctx.data.stashed_items or {}
       local filter_map = {}
 			local inv = meta:get_inventory()
@@ -77,8 +77,8 @@ minetest.register_node("epic:stash_inv", {
       end
 
       if items_stashed then
-			minetest.log("action", ("%s's inventory has had items stashed: { %s }")
-				:format(player:get_player_name(), stashed_string:sub(1, -3)))
+			minetest.log("action", ("[epic::stash_inventory@%s] %s's inventory has had items stashed: { %s }")
+				:format(minetest.pos_to_string(pos), player:get_player_name(), stashed_string:sub(1, -3)))
       end
 
 			ctx.next()

--- a/blocks/stash_inventory.lua
+++ b/blocks/stash_inventory.lua
@@ -61,14 +61,23 @@ minetest.register_node("epic:stash_inv", {
       local player_inv = player:get_inventory()
       local filter_all = filter_items_count == 0 -- no filter means stash EVERYTHING!
       local i = 1
+      local stashed_string = ""
+      local items_stashed = false
       while i <= player_inv:get_size("main") do
         local stack = player_inv:get_stack("main", i)
-        if filter_all or filter_map[stack:get_name()] then
+        if not stack:is_empty() and filter_all or filter_map[stack:get_name()] then
           player_inv:set_stack("main", i, ItemStack(nil))
-          table.insert(ctx.data.stashed_items, stack:to_string())
+          local stack_str = stack:to_string()
+          stashed_string = stashed_string .. stack_str .. ", "
+          items_stashed = true
+          table.insert(ctx.data.stashed_items, stack_str)
         end
 
         i = i + 1
+      end
+
+      if items_stashed then
+			minetest.log("action", ("%s's inventory has had items stashed: { %s }"):format(player:get_player_name(), stashed_string:sub(1, -3)))
       end
 
 			ctx.next()

--- a/blocks/teleport.lua
+++ b/blocks/teleport.lua
@@ -53,6 +53,7 @@ minetest.register_node("epic:teleport", {
     on_enter = function(pos, meta, player, ctx)
 			local rel_pos = minetest.string_to_pos(meta:get_string("pos"))
 			local target_pos = epic.to_absolute_pos(pos, rel_pos)
+			minetest.log("action", ("teleported %s to %s"):format(player:get_player_name(), minetest.pos_to_string(target_pos)))
 			player:set_pos(target_pos)
 			ctx.next()
     end

--- a/blocks/teleport.lua
+++ b/blocks/teleport.lua
@@ -53,7 +53,8 @@ minetest.register_node("epic:teleport", {
     on_enter = function(pos, meta, player, ctx)
 			local rel_pos = minetest.string_to_pos(meta:get_string("pos"))
 			local target_pos = epic.to_absolute_pos(pos, rel_pos)
-			minetest.log("action", ("teleported %s to %s"):format(player:get_player_name(), minetest.pos_to_string(target_pos)))
+			minetest.log("action", ("[epic::teleport@%s] teleported %s to %s")
+				:format(minetest.pos_to_string(pos), player:get_player_name(), minetest.pos_to_string(target_pos)))
 			player:set_pos(target_pos)
 			ctx.next()
     end

--- a/blocks/teleport_relative.lua
+++ b/blocks/teleport_relative.lua
@@ -83,6 +83,7 @@ minetest.register_node("epic:teleport_relative", {
 				local delta = vector.subtract(player_pos, source_pos)
 				local new_pos = vector.add(target_pos, delta)
 				-- TODO: account for player:get_velocity()
+				minetest.log("action", ("teleported %s to %s"):format(player:get_player_name(), minetest.pos_to_string(new_pos)))
 				player:set_pos(new_pos)
 			end
 			ctx.next()

--- a/blocks/teleport_relative.lua
+++ b/blocks/teleport_relative.lua
@@ -83,7 +83,8 @@ minetest.register_node("epic:teleport_relative", {
 				local delta = vector.subtract(player_pos, source_pos)
 				local new_pos = vector.add(target_pos, delta)
 				-- TODO: account for player:get_velocity()
-				minetest.log("action", ("teleported %s to %s"):format(player:get_player_name(), minetest.pos_to_string(new_pos)))
+				minetest.log("action", ("[epic::teleport_relative@%s] teleported %s to %s")
+					:format(minetest.pos_to_string(pos), player:get_player_name(), minetest.pos_to_string(new_pos)))
 				player:set_pos(new_pos)
 			end
 			ctx.next()

--- a/blocks/unstash_inventory.lua
+++ b/blocks/unstash_inventory.lua
@@ -11,14 +11,21 @@ minetest.register_node("epic:unstash_inv", {
     on_enter = function(_, _, player, ctx)
       ctx.data.stashed_items = ctx.data.stashed_items or {}
 			local player_inv = player:get_inventory()
+			local unstashed_string = ""
+			local items_unstashed = false
 
-			for _, itemstr in ipairs(ctx.data.stashed_items) do
+			for i, itemstr in ipairs(ctx.data.stashed_items) do
 				local stack = ItemStack(itemstr)
 				if player_inv:room_for_item("main", stack) then
+					unstashed_string = unstashed_string..itemstr..", "
+					items_unstashed = true
 					player_inv:add_item("main", stack)
+					ctx.data.stashed_items[i] = nil
 				end
 			end
-
+			if items_unstashed then
+				minetest.log("action", ("%s's inventory has had items restored: { %s }"):format(player:get_player_name(), unstashed_string:sub(1, -3)))
+			end
 			ctx.next()
     end
   }

--- a/blocks/unstash_inventory.lua
+++ b/blocks/unstash_inventory.lua
@@ -24,7 +24,8 @@ minetest.register_node("epic:unstash_inv", {
 				end
 			end
 			if items_unstashed then
-				minetest.log("action", ("%s's inventory has had items restored: { %s }"):format(player:get_player_name(), unstashed_string:sub(1, -3)))
+				minetest.log("action", ("%s's inventory has had items restored: { %s }")
+					:format(player:get_player_name(), unstashed_string:sub(1, -3)))
 			end
 			ctx.next()
     end

--- a/blocks/unstash_inventory.lua
+++ b/blocks/unstash_inventory.lua
@@ -8,7 +8,7 @@ minetest.register_node("epic:unstash_inv", {
 	on_rotate = epic.on_rotate,
 
 	epic = {
-    on_enter = function(_, _, player, ctx)
+    on_enter = function(pos, _, player, ctx)
       ctx.data.stashed_items = ctx.data.stashed_items or {}
 			local player_inv = player:get_inventory()
 			local unstashed_string = ""
@@ -24,8 +24,8 @@ minetest.register_node("epic:unstash_inv", {
 				end
 			end
 			if items_unstashed then
-				minetest.log("action", ("%s's inventory has had items restored: { %s }")
-					:format(player:get_player_name(), unstashed_string:sub(1, -3)))
+				minetest.log("action", ("[epic::unstash_inventory@%s] %s's inventory has had items restored: { %s }")
+					:format(minetest.pos_to_string(pos), player:get_player_name(), unstashed_string:sub(1, -3)))
 			end
 			ctx.next()
     end


### PR DESCRIPTION
Fixes https://github.com/BlockySurvival/issue-tracker/issues/354

I've added action logs for any actions performed by epic blocks that mess with a player in some significant way, this should allow changes to be un-done if something goes wrong.

Most of the changes simply add in the log call and some build a string of what's changed, however I have made a few behaviour "changes" that seemed necessary:

- add_item: returns early if the stack is empty
- deduct_inventory: a stack is not deducted from a players inventory if the stack is empty
- remove_item: do not attempt to remove a player entity
- stash_inventory: do not stash an empty stack (this was resulting in many empty strings in the list, unstash doesn't restore gaps anyways so no need for them)
- unstash_inventory: items are removed from the stash store once they are unstashed